### PR TITLE
feat: Componet any, some 처리 추가

### DIFF
--- a/CommonListKit/Sources/Component/Component.swift
+++ b/CommonListKit/Sources/Component/Component.swift
@@ -33,6 +33,13 @@ protocol Component: Hashable {
     var identifier: String { get }
     
     /**
+     크기 계산용 hash 처리 함수
+     
+     - Parameter hasher: 해시 처리를 위한 Hasher 객체
+     */
+    func sizeHash(into hasher: inout Hasher)
+    
+    /**
      `'Contnet'` View에 데이터 적용하는 함수
      
      - Parameters:
@@ -49,4 +56,12 @@ protocol Component: Hashable {
 
 extension Component {
     func renderContent() -> Content { Content() }
+}
+
+extension Component {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(identifier)
+        
+        sizeHash(into: &hasher)
+    }
 }

--- a/CommonListKit/Sources/Component/Component.swift
+++ b/CommonListKit/Sources/Component/Component.swift
@@ -39,4 +39,14 @@ protocol Component: Hashable {
         - content: Component에 매칭되어 데이터를 적용할 Content View
      */
     func render(content: Content)
+    /**
+     렌더링할 `'Contnet'` View를 생성하여 반환해주는 함수
+     
+     - Returns: 렌더링할 Content 뷰
+     */
+    func renderContent() -> Content
+}
+
+extension Component {
+    func renderContent() -> Content { Content() }
 }

--- a/CommonListKit/Sources/Component/ComponentWrapper.swift
+++ b/CommonListKit/Sources/Component/ComponentWrapper.swift
@@ -29,6 +29,15 @@ struct ComponentWrapper: Component {
     }
     
     /**
+     크기 계산용 hash 처리 함수
+     
+     - Parameter hasher: 해시 처리를 위한 Hasher 객체
+     */
+    func sizeHash(into hasher: inout Hasher) {
+        original.sizeHash(into: &hasher)
+    }
+    
+    /**
      `'Contnet'` View에 데이터 적용하는 함수
      
      - Parameters:

--- a/CommonListKit/Sources/Component/ComponentWrapper.swift
+++ b/CommonListKit/Sources/Component/ComponentWrapper.swift
@@ -1,0 +1,83 @@
+//
+//  ComponentWrapper.swift
+//  CommonListKit
+//
+//  Created by 박기석 on 11/12/24.
+//
+
+import UIKit
+
+/**
+ Component 프로토콜 any, some 처리 편리성을 위한 Wrapper
+ */
+struct ComponentWrapper: Component {
+    private let container: any ComponentContainerProtocol
+    /// 원래 Component 값
+    var original: any Component { container.component }
+    
+    /// Component 고유 ID 값 설정
+    var identifier: String { original.identifier }
+    
+    /** 
+     ComponentWrapper 초기화
+     
+     - Parameters:
+        - component: Wrapping 처리할 Component
+     */
+    init(_ component: some Component) {
+        container = ComponentContainer(component: component)
+    }
+    
+    /**
+     `'Contnet'` View에 데이터 적용하는 함수
+     
+     - Parameters:
+        - content: Component에 매칭되어 데이터를 적용할 Content View
+     */
+    func render(content: UIView) {
+        container.render(content: content)
+    }
+    
+    /**
+     렌더링할 `'Contnet'` View를 생성하여 반환해주는 함수
+     
+     - Returns: 렌더링할 Content 뷰
+     */
+    func renderContent() -> UIView {
+        container.renderContent()
+    }
+    
+    static func == (lhs: ComponentWrapper, rhs: ComponentWrapper) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+}
+
+private protocol ComponentContainerProtocol {
+    associatedtype Base: Component
+
+    var component: Base { get }
+    var identifier: String { get }
+
+    func renderContent() -> UIView
+    func render(content: UIView)
+}
+
+private struct ComponentContainer<Base: Component>: ComponentContainerProtocol {
+    var identifier: String { component.identifier }
+    
+    var component: Base
+    
+    init(component: Base) {
+        self.component = component
+    }
+    
+    func renderContent() -> UIView {
+        component.renderContent()
+    }
+    
+    func render(content: UIView) {
+        guard let content = content as? Base.Content else { return }
+        
+        component.render(content: content)
+    }
+}

--- a/CommonListKit/Sources/Section/Section.swift
+++ b/CommonListKit/Sources/Section/Section.swift
@@ -19,11 +19,11 @@ struct Section: Hashable {
     /// 아이템과 아이템 간격
     let minimumInteritemSpacing: CGFloat
     /// 섹션 Header Component
-    let header: (any Component)?
+    let header: ComponentWrapper?
     /// 섹션 Footer Component
-    let footer: (any Component)?
+    let footer: ComponentWrapper?
     /// 섹션 아이템 Component 배열
-    let items: [any Component]
+    let items: [ComponentWrapper]
     
     init(identifier: String,
          minimumLineSpacing: CGFloat = 0,
@@ -32,11 +32,22 @@ struct Section: Hashable {
          footer: (any Component)? = nil,
          items: [any Component]) {
         self.identifier = identifier
+        
         self.minimumLineSpacing = minimumLineSpacing
         self.minimumInteritemSpacing = minimumInteritemSpacing
-        self.header = header
-        self.footer = footer
-        self.items = items
+        
+        self.header = if let header {
+            ComponentWrapper(header)
+        } else {
+            nil
+        }
+        self.footer = if let footer {
+            ComponentWrapper(footer)
+        } else {
+            nil
+        }
+        
+        self.items = items.map { ComponentWrapper($0) }
     }
     
     func hash(into hasher: inout Hasher) {

--- a/CommonListKitTests/Sources/Component/ComponentTests.swift
+++ b/CommonListKitTests/Sources/Component/ComponentTests.swift
@@ -12,7 +12,7 @@ import Nimble
 final class ComponentTests: QuickSpec {
     override class func spec() {
         var component1: DummyComponent!
-        var component2: (any Component)!
+        var component2: DummyComponent!
         
         describe("Component 유효성") {
             context("Component 동일성 검사 1") {
@@ -23,7 +23,8 @@ final class ComponentTests: QuickSpec {
                 }
                 
                 it("같은 경우") {
-                    expect(component1.identifier).to(equal(component2?.identifier))
+                    expect(component1.identifier).to(equal(component2.identifier))
+                    expect(component1.hashValue).to(equal(component2.hashValue))
                 }
                 
                 afterEach {
@@ -40,6 +41,7 @@ final class ComponentTests: QuickSpec {
                 
                 it("같지 않은 경우") {
                     expect(component1.identifier).toNot(equal(component2.identifier))
+                    expect(component1.hashValue).toNot(equal(component2.hashValue))
                 }
                 
                 afterEach {

--- a/CommonListKitTests/Sources/Section/SectionTests.swift
+++ b/CommonListKitTests/Sources/Section/SectionTests.swift
@@ -11,18 +11,20 @@ import Nimble
 
 final class SectionTests: QuickSpec {
     override class func spec() {
-        let section1 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component")])
+        var section1: Section!
         var section2: Section!
         
         describe("Section 판별") {
             context("동일성 검사") {
                 beforeEach {
+                    section1 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component")])
                     section2 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component")])
                 }
                 
                 it("같은 경우") {
                     expect(section1).to(equal(section2))
                     expect(section1.identifier).to(equal(section2.identifier))
+                    expect(section1.hashValue).to(equal(section2.hashValue))
                 }
                 
                 afterEach {
@@ -32,12 +34,14 @@ final class SectionTests: QuickSpec {
             
             context("identifier 검사") {
                 beforeEach {
+                    section1 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component")])
                     section2 = Section(identifier: "section_2", items: [DummyComponent(identifier: "dummy_component")])
                 }
                 
                 it("다른 경우") {
                     expect(section1).toNot(equal(section2))
                     expect(section1.identifier).toNot(equal(section2.identifier))
+                    expect(section1.hashValue).toNot(equal(section2.hashValue))
                 }
                 
                 afterEach {
@@ -47,11 +51,13 @@ final class SectionTests: QuickSpec {
             
             context("items 검사") {
                 beforeEach {
+                    section1 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component")])
                     section2 = Section(identifier: "section_1", items: [DummyComponent(identifier: "dummy_component_1")])
                 }
                 
                 it("다른 경우") {
                     expect(section1).toNot(equal(section2))
+                    expect(section1.hashValue).toNot(equal(section2.hashValue))
                 }
                 
                 afterEach {


### PR DESCRIPTION
# 작업사항

- `Component`에 **hash** 처리 추가
- `Component`에 `Content` 생성을 위한 함수 정의 추가
- **any**, **some** 처리를 위한 `ComponentWrapper` 추가
- `Section`에 **any Component** 처리 `ComponentWrapper`로 변경
- Component, Section 개선에 따른 Test 코드 개선